### PR TITLE
chore: migrate Docker build workflow to reusable-workflows

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,5 +1,5 @@
-
 name: Deploy
+
 on:
   push:
     branches:
@@ -7,35 +7,9 @@ on:
 
 jobs:
   deploy:
+    uses: S-mishina/reusable-workflows/.github/workflows/docker-build-push.yml@main
+    with:
+      image-name: s-mishina/thread_pool_task_executor_sandbox
     permissions:
-      packages: write
       contents: read
-      attestations: write
-      id-token: write
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.9.0
-        with:
-          driver-opts: |
-            image=moby/buildkit:v0.10.6
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          logout: false
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          platforms: linux/amd64
-          push: true
-          tags: |
-            ghcr.io/s-mishina/thread_pool_task_executor_sandbox:${{ github.sha }}
-            ghcr.io/s-mishina/thread_pool_task_executor_sandbox:latest
+      packages: write

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,10 @@
+---
+extends: default
+
+rules:
+  line-length:
+    max: 256
+  truthy:
+    check-keys: false
+  comments:
+    min-spaces-from-content: 1


### PR DESCRIPTION
This pull request streamlines the deployment workflow and adds configuration for YAML linting. The main changes involve switching to a reusable workflow for Docker image building and pushing, and introducing a `.yamllint.yaml` file to enforce YAML formatting standards.

**Deployment workflow improvements:**

* Replaces the custom deployment steps in `.github/workflows/deploy.yaml` with a call to a reusable workflow (`docker-build-push.yml`), simplifying the deployment process and reducing maintenance overhead.

**Linting and code quality:**

* Adds a `.yamllint.yaml` configuration file to enforce YAML linting rules, such as increasing the maximum line length to 256, adjusting truthy value checks, and requiring spacing for comments.